### PR TITLE
unifies alert and getKpis

### DIFF
--- a/components/sla-manager-svc/app/assessment/evaluator.go
+++ b/components/sla-manager-svc/app/assessment/evaluator.go
@@ -72,7 +72,7 @@ func AssessActiveQoSDefinitions(cfg Config) {
 		grouped_qosdefs, err := groupSLAsByServiceId(qosdefs, repo)
 		if err == nil {
 
-			var violations []model.OutputSLA // list of all violations
+			var violations []model.ColmenaOutputSLA // list of all violations
 			var statuses []model.OutputSLA   // list of all violations
 
 			// iterate SLA evaluation results

--- a/components/sla-manager-svc/app/assessment/notifier/lognotifier/lognotifier.go
+++ b/components/sla-manager-svc/app/assessment/notifier/lognotifier/lognotifier.go
@@ -70,7 +70,7 @@ func (n LogNotifier) NotifyStatus(qos *model.SLA, result *assessment_model.Resul
 }
 
 /* Implements notifier.NotifyAllViolations */
-func (n LogNotifier) NotifyAllViolations(results []model.OutputSLA) {
+func (n LogNotifier) NotifyAllViolations(results []model.ColmenaOutputSLA) {
 	logs.GetLogger().Warn(pathLOG + "Function not implemented")
 }
 

--- a/components/sla-manager-svc/app/assessment/notifier/violations.go
+++ b/components/sla-manager-svc/app/assessment/notifier/violations.go
@@ -25,7 +25,7 @@ import (
 type ViolationNotifier interface {
 	NotifyViolations(agreement *model.SLA, result *assessment_model.Result)
 
-	NotifyAllViolations(results []model.OutputSLA)
+	NotifyAllViolations(results []model.ColmenaOutputSLA)
 
 	NotifyStatus(agreement *model.SLA, result *assessment_model.Result)
 

--- a/components/sla-manager-svc/app/assessment/notifier_funcs.go
+++ b/components/sla-manager-svc/app/assessment/notifier_funcs.go
@@ -20,14 +20,15 @@ package assessment
 
 import (
 	amodel "colmena/sla-management-svc/app/assessment/model"
+	"colmena/sla-management-svc/app/common/logs"
 	"colmena/sla-management-svc/app/model"
 )
 
-func GenerateViolationOutput(qos model.SLA, result amodel.Result) model.OutputSLA {
+func GenerateViolationOutput(qos model.SLA, result amodel.Result) model.ColmenaOutputSLA {
 
 	vs := result.GetViolations()
 	if len(vs) == 0 {
-		return model.OutputSLA{}
+		return model.ColmenaOutputSLA{}
 	}
 
 	/*
@@ -48,20 +49,10 @@ func GenerateViolationOutput(qos model.SLA, result amodel.Result) model.OutputSL
 			]
 		}
 	*/
-	output := model.OutputSLA{
-		ServiceId: qos.Name,
-		SLAId:     qos.Id,
-		Kpis: []model.OutputSLAKpi{
-			{
-				RoleId:          qos.Id,
-				Query:           qos.Details.Guarantees[0].Query,
-				Value:           vs[0].Values[0].Value,
-				Level:           qos.Assessment.Level,
-				Threshold:       qos.Assessment.Threshold, //qos.Details.Guarantees[0].Query,
-				Violations:      vs,
-				TotalViolations: qos.Assessment.TotalViolations,
-			},
-		},
+	output, err := model.SLAModelToColmenaOutputSLA(qos)
+	if err != nil {
+		logs.GetLogger().Error("Error generating violation output: ", err)
+		return model.ColmenaOutputSLA{}
 	}
 
 	return output

--- a/components/sla-manager-svc/app/model/iomodels.go
+++ b/components/sla-manager-svc/app/model/iomodels.go
@@ -108,6 +108,21 @@ Output model (SLA VIOLATION) example:
 		]
 	}
 */
+
+type ColmenaOutputSLA struct {
+	ServiceId string         `json:"serviceId"`
+	Kpis      []ColmenaOutputKpis `json:"KPIs"`
+}
+
+type ColmenaOutputKpis struct {
+	RoleId 			string `json:"roleId"`
+	Query 			string `json:"query"`
+	Level           string      `json:"level"`
+	Value 			interface{} `json:"value"`
+	Threshold       float64     `json:"threshold"`
+}
+
+
 type OutputSLA struct {
 	ServiceId string         `json:"serviceId"`
 	SLAId     string         `json:"slaId"`

--- a/components/sla-manager-svc/app/model/transformation.go
+++ b/components/sla-manager-svc/app/model/transformation.go
@@ -37,28 +37,28 @@ func SLAModelToColmenaOutputSLA(qos SLA) (ColmenaOutputSLA, error) {
 	res := float64(-1)
 	updated := false
 
-	if qos.Assessment.Level != ASSESSMENT_LEVEL_NORESULTS && len(qos.Assessment.Guarantees) > 0 {
-		for key := range qos.Assessment.Guarantees {
-			//res = qos.Assessment.Guarantees[key].LastValues
+	//if qos.Assessment.Level != ASSESSMENT_LEVEL_NORESULTS && len(qos.Assessment.Guarantees) > 0 {
+	for key := range qos.Assessment.Guarantees {
+		//res = qos.Assessment.Guarantees[key].LastValues
 
-			if len(qos.Assessment.Guarantees[key].LastValues) > 0 {
-				for key2 := range qos.Assessment.Guarantees[key].LastValues {
-					if len(key2) > 0 {
-						r, ok := qos.Assessment.Guarantees[key].LastValues[key2].Value.(float64)
-						if !ok {
-							logs.GetLogger().Error(" Value is not a number")
-						} else {
-							updated = true
-							res = r
-						}
-						//logs.GetLogger().Debugf(pathLOG + " break")
-						break
+		if len(qos.Assessment.Guarantees[key].LastValues) > 0 {
+			for key2 := range qos.Assessment.Guarantees[key].LastValues {
+				if len(key2) > 0 {
+					r, ok := qos.Assessment.Guarantees[key].LastValues[key2].Value.(float64)
+					if !ok {
+						logs.GetLogger().Error(" Value is not a number")
+					} else {
+						updated = true
+						res = r
 					}
+					//logs.GetLogger().Debugf(pathLOG + " break")
+					break
 				}
 			}
-
 		}
+
 	}
+	//}
 
 	kpis := []ColmenaOutputKpis{}
 


### PR DESCRIPTION
when no results then role selector receives:
```
2025/07/29 14:25:31 KPI query: avg_over_time(examplecontextdata_processing_time[5m]) < 1, associated role: Getter, level: Unknown_NoResults
2025/07/29 14:25:32 Received alert: {"serviceId":"ExampleContextdata","KPIs":[]}
2025/07/29 14:25:32 Received alert for service:  ExampleContextdata
```

when there is a kpi violation role selector receives
```
2025/07/29 14:31:29 Received alert: [{"serviceId":"ExampleContextdata","KPIs":[{"roleId":"Getter","query":"avg_over_time(examplecontextdata_processing_time[5m]) \u003c 1","level":"Broken","value":2,"threshold":1}]}]
2025/07/29 14:31:29 Received alert for service:  ExampleContextdata
2025/07/29 14:31:29 KPI query: avg_over_time(examplecontextdata_processing_time[5m]) < 1, associated role: Getter, level: Broken
```

when there is no kpi violation role selector receives
```
2025/07/30 09:11:05 KPI query: avg_over_time(examplecontextdata_processing_time[5m]) < 50, associated role: Getter, level: Unknown_NoResults
2025/07/30 09:11:05 Received alert: {"serviceId":"ExampleContextdata","KPIs":[{"roleId":"Getter","query":"avg_over_time(examplecontextdata_processing_time[5m]) \u003c 50","level":"Unknown_NoResults","value":2,"threshold":50}]}
2025/07/30 09:11:05 Received alert for service:  ExampleContextdata
```