### PR TITLE
Fixes metrics-etl freeze and SLA CheckTime misconfiguration

### DIFF
--- a/components/metrics-etl/metrics_etl/etl.py
+++ b/components/metrics-etl/metrics_etl/etl.py
@@ -17,6 +17,7 @@ This work has been implemented within the context of COLMENA project.
 """
 import logging
 import json
+import signal
 from prometheus_client import Gauge, start_http_server
 from zenoh import open, Config, Sample
 from metrics_etl.config import AGENT_ID, ZENOH_CONFIG_FILE, PROMETHEUS_PORT, VERSION
@@ -143,8 +144,8 @@ def start_etl():
         context_subscriber = session.declare_subscriber(f"colmena/contexts/{AGENT_ID}/**", context_listener)
         logger.info(f"Subscribed to colmena/contexts/**")
 
-        while True:
-            pass  # Keeps running
+        signal.pause()
+            time.sleep(1)  # Keeps running
 
     except Exception as error:
         logger.error(f"Failed to start ETL: {error}")

--- a/components/sla-manager-svc/main.go
+++ b/components/sla-manager-svc/main.go
@@ -201,7 +201,7 @@ func createMainConfig() *viper.Viper {
 	logs.GetLogger().Info(pathLOG + "[Configuration] Setting configuration values ...")
 
 	// CheckPeriod
-	config.SetDefault(cfg.CheckPeriodPropertyName, cfg.DefaultCheckPeriod)
+	setConfigValue(config, cfg.CheckPeriodPropertyName, cfg.DefaultCheckPeriod.String())
 
 	// TransientTime
 	config.SetDefault(cfg.TransientTimePropertyName, cfg.DefaultTransientTime)


### PR DESCRIPTION
# Description
Two issues:
metrics-etl freezing due to fast loop without sleep
sla-manager not setting SLA CheckTime properly

[Issue link](https://github.com/eviden-colmena/colmena-eviden/issues/BRSE-REPLACE)

# How was this tested? 
Tested directly using FABRIC, a distributed setup involving multiple nodes and sites

# Follow-up PRs

# Related PRs
